### PR TITLE
Lot article publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,8 +34,8 @@ steps:
     targetType: 'inline' # Optional. Options: filePath, inline
     #filePath: # Required when targetType == FilePath
     #arguments: # Optional
-    script: find $(Build.ArtifactStagingDirectory) \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;
-    #workingDirectory: # Optional
+    script: find . \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     #failOnStderr: false # Optional
 # Publish Build Artifacts
 # Publish build artifacts to Azure Artifacts/TFS or a file share

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ steps:
 
 - task: Bash@3
   inputs:
-    #targetType: 'filePath' # Optional. Options: filePath, inline
+    targetType: 'inline' # Optional. Options: filePath, inline
     #filePath: # Required when targetType == FilePath
     #arguments: # Optional
     script: find $(Build.ArtifactStagingDirectory) \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,10 +25,18 @@ steps:
 #    sass --update assets/stylesheets/sass:assets/stylesheets/css --style compressed 
 #  displayName: 'Jekyll build'
   
-- script: |
+- script:
     bundle exec jekyll build --destination $(Build.ArtifactStagingDirectory)  
   displayName: 'Jekyll build'
 
+- task: Bash@3
+  inputs:
+    #targetType: 'filePath' # Optional. Options: filePath, inline
+    #filePath: # Required when targetType == FilePath
+    #arguments: # Optional
+    script: find $(Build.ArtifactStagingDirectory) \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;
+    #workingDirectory: # Optional
+    #failOnStderr: false # Optional
 # Publish Build Artifacts
 # Publish build artifacts to Azure Artifacts/TFS or a file share
 - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Fixed encoding issue. HTML, CSS and js files are encoded with gzip. Azure pipeline configuration file has been updated to perform encoding via gzip using bash. 